### PR TITLE
fix parallel extraction

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function streamResults(args, options, cb) {
   child.stderr.setEncoding('utf8')
   child.stdout.on('data', stdoutHandler)
   child.stderr.on('data', stderrHandler)
-  child.on('exit', exitHandler)
+  child.on('close', closeHandler)
 
   function stdoutHandler(data) {
     output += data
@@ -62,7 +62,7 @@ function streamResults(args, options, cb) {
     stderr += data
   }
 
-  function exitHandler(code) {
+  function closeHandler(code) {
     if (code !== 0) {
       return cb(new Error('pdf-text-extract command failed: ' + stderr))
     }

--- a/test/extract-test.js
+++ b/test/extract-test.js
@@ -30,6 +30,22 @@ describe('Pdf extract', function () {
     })
   })
 
+  it('should work with parallel data streams', function (done) {
+    var filePath = path.join(__dirname, 'data', 'pdf with space in name.pdf')
+
+    var streams = 10, complete = 0;
+    for(var i = 0; i < streams; i++) {
+      extract(filePath, function (err, pages) {
+        should.not.exist(err)
+        should.exists(pages[0])
+        complete++;
+        if(complete === streams) {
+          done()
+        }
+      })
+    }
+  })
+
   it('should allow large files', function (done) {
     this.timeout(5000)
     this.slow('4s')


### PR DESCRIPTION
- wait for stdio streams to close

See http://nodejs.org/api/child_process.html#child_process_event_close

Discovered this bug when https://github.com/dbashford/textract returned empty texts from easily extractable pdfs.