### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test/
+.travis.yml

--- a/README.md
+++ b/README.md
@@ -30,10 +30,34 @@ extract(filePath, function (err, pages) {
   console.dir(pages)
 })
 ```
-The output will be an array of where each entry is a page of text. If you want just a string of all pages you can do `pages.join(' ')`
+The output will be an array of where each entry is a page of text. If you want just a string of all pages you can set the option to `splitPages: false`.
+
+```javascript
+var filePath = path.join(__dirname, 'test/data/multipage.pdf')
+var extract = require('pdf-text-extract')
+extract(filePath, { splitPages: false }, function (err, text) {
+  if (err) {
+    console.dir(err)
+    return
+  }
+  console.dir(text)
+})
+```
+
+You can set the following options:
+- firstPage: First page to extract
+- lastPage: Last page to extract
+- resolution: in dpi, as is specified by pdftotext -r
+- crop: Should be an object { x:x, y:y, w:w, h:h }
+- layout: Should be either 'layout', 'raw' or 'htmlmeta'. Default: 'layout'
+- encoding: Should be either 'UCS-2', 'ASCII7', 'Latin1', 'UTF-8', 'ZapfDingbats' or 'Symbol'. Default: 'UTF-8'
+- eol: End of line convention. One of either: 'unix', 'dos' or 'mac'
+- ownerPassword: Owner password (for encrypted files)
+- userPassword: User password (for encrypted files)
+- splitPages: If true, the result will be and array of pages. Default: true.
 
 
-If needed you can pass an optional arguments to the extract function. These will be passed to the command
+If needed you can pass an optional arguments to the extract function. These will be passed to the `child_process.spawn` call.
 
 ```javascript
 var filePath = path.join(__dirname, 'test/data/multipage.pdf')
@@ -49,6 +73,8 @@ extract(filePath, options, function (err, pages) {
   console.dir('extracted pages', pages)
 })
 ```
+
+
 
 ## As a command line tool
 

--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ extract(filePath, { splitPages: false }, function (err, text) {
 ```
 
 You can set the following options:
-- firstPage: First page to extract
-- lastPage: Last page to extract
-- resolution: in dpi, as is specified by pdftotext -r
-- crop: Should be an object { x:x, y:y, w:w, h:h }
-- layout: Should be either 'layout', 'raw' or 'htmlmeta'. Default: 'layout'
-- encoding: Should be either 'UCS-2', 'ASCII7', 'Latin1', 'UTF-8', 'ZapfDingbats' or 'Symbol'. Default: 'UTF-8'
-- eol: End of line convention. One of either: 'unix', 'dos' or 'mac'
-- ownerPassword: Owner password (for encrypted files)
-- userPassword: User password (for encrypted files)
-- splitPages: If true, the result will be and array of pages. Default: true.
+- `firstPage`: First page to extract
+- `lastPage`: Last page to extract
+- `resolution`: in dpi, as is specified by pdftotext -r
+- `crop`: Should be an object { x:x, y:y, w:w, h:h }
+- `layout`: Should be either `layout`, `raw` or `htmlmeta`. Default: `layout`
+- `encoding`: Should be either `UCS-2`, `ASCII7`, `Latin1`, `UTF-8`, `ZapfDingbats` or `Symbol`. Default: `UTF-8`
+- `eol`: End of line convention. One of either: `unix`, `dos` or `mac`
+- `ownerPassword`: Owner password (for encrypted files)
+- `userPassword`: User password (for encrypted files)
+- `splitPages`: If true, the result will be and array of pages. Default: true.
 
 
 If needed you can pass an optional arguments to the extract function. These will be passed to the `child_process.spawn` call.

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var spawn = require('child_process').spawn
 
 module.exports = function pdfTextExtract(filePath, options, cb) {
 
-  // 'options' is an optional argument
+  // options is optional
   if (typeof(options) === 'function') {
     cb = options
     options = {}
@@ -11,20 +11,49 @@ module.exports = function pdfTextExtract(filePath, options, cb) {
 
   filePath = path.resolve(filePath)
 
-  var defaultArgs = [
-    '-layout',
-    '-enc',
-    'UTF-8',
-    filePath,
-    '-'
-  ];
+  // default options
+  options.encoding    = options.encoding || 'UTF-8'
+  options.layout      = options.layout   || 'layout'
+  options.splitPages  = (options.splitPages !== false)
 
-  var args = defaultArgs;
-  if (options.args) {
-    args = options.args;
-  };
+  // Build args based on options
+  var args = []
 
-  streamResults(args, options, splitPages)
+  // First and last page to convert
+  if (options.firstPage) { args.push('-f'); args.push(options.firstPage) }
+  if (options.lastPage)  { args.push('-l'); args.push(options.lastPage) }
+
+  // Resolution, in dpi. (null is pdftotext default = 72)
+  if (options.resolution) { args.push('-r'); args.push(options.resolution) }
+
+  // If defined, should be an object { x:x, y:y, w:w, h:h }
+  if (typeof(options.crop) === 'object') { 
+    if (options.crop.x) { args.push('-x'); args.push(options.crop.x) }
+    if (options.crop.y) { args.push('-y'); args.push(options.crop.y) }
+    if (options.crop.w) { args.push('-W'); args.push(options.crop.w) }
+    if (options.crop.h) { args.push('-H'); args.push(options.crop.h) }
+  }
+  
+  // One of either 'layout', 'raw' or 'htmlmeta'
+  if (options.layout === 'layout')    args.push('-layout')
+  if (options.layout === 'raw')       args.push('-raw')
+  if (options.layout === 'htmlmeta')  args.push('-htmlmeta')
+
+  // Output text encoding (UCS-2, ASCII7, Latin1, UTF-8, ZapfDingbats or Symbol)
+  if (options.encoding) { args.push('-enc'); args.push(options.encoding) }
+
+  // Output end of line convention (unix, dos or mac)
+  if (options.eol) { args.push('-eol'); args.push(options.eol) }
+
+  // Owner and User password (for encrypted files)
+  if (options.ownerPassword) { args.push('-opw'); args.push(options.ownerPassword) }
+  if (options.userPassword)  { args.push('-upw'); args.push(options.userPassword) }
+
+  // finish up arguments
+  args.push(filePath)
+  args.push('-')
+
+  streamResults(args, options, options.splitPages ? splitPages : cb)
 
   function splitPages(err, content) {
     if (err) {

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 var path = require('path')
 var spawn = require('child_process').spawn
+
 module.exports = function pdfTextExtract(filePath, options, cb) {
+
+  // 'options' is an optional argument
   if (typeof(options) === 'function') {
     cb = options
     options = {}
   }
+
   filePath = path.resolve(filePath)
 
   var defaultArgs = [
@@ -43,6 +47,10 @@ module.exports = function pdfTextExtract(filePath, options, cb) {
     cb(null, pages)
   }
 }
+
+/**
+ * spawns pdftotext and returns its output
+ */
 function streamResults(args, options, cb) {
   var output = ''
   var stderr = ''


### PR DESCRIPTION
This should save some bandwidth to npm by ignoring tests and development files when installing the module.

There are some huge pdf files in that folder that don't need to be downloaded every time this module gets installed.